### PR TITLE
Hopper macros | Refactor  + Derive(Serialize) + minor version bump

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopper_macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Macros for internal use in hopper (https://github.com/BRA1L0R/hopper-rs)"

--- a/macros/src/errors.rs
+++ b/macros/src/errors.rs
@@ -1,0 +1,17 @@
+use std::fmt::Display;
+
+/// Errors used in hopper_macros.
+#[derive(Debug)]
+pub enum Error {
+    /// Used when an invalid struct (enum or with unnamed fields) gets parsed.
+    InvalidStructErr,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Invalid Struct Error (enum or unnamed fields)");
+        Ok(())
+    }
+}
+
+impl std::error::Error for Error {}

--- a/macros/src/errors.rs
+++ b/macros/src/errors.rs
@@ -9,8 +9,7 @@ pub enum Error {
 
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("Invalid Struct Error (enum or unnamed fields)");
-        Ok(())
+        f.write_str("Invalid Struct Error (enum or unnamed fields)")
     }
 }
 

--- a/macros/src/parser.rs
+++ b/macros/src/parser.rs
@@ -1,0 +1,65 @@
+use crate::errors::Error;
+use syn::{Ident, Type, DataStruct, DeriveInput, Data};
+
+
+/// # Parses derive macro input.
+/// ## Success
+///
+/// In case of success, returns tuple with:
+/// Vector of field idents ( Vec<syn::Ident>  );
+/// Vector of field types  ( Vec<syn::Type>   );
+/// Ident (name) of the parsed struct (syn::Ident);
+///
+/// ---
+///
+/// ## Error
+///
+/// In case of wrong input, it returns a compile time error.
+macro_rules! parse_input {
+    ($input:ident) => {
+        if let Ok(v) = crate::parser::parse_derive_input(&syn::parse_macro_input!($input as syn::DeriveInput)) {
+            v
+        } else {
+            return r#"compile_error!("Unsupported data structure.\nDon't use enums or unnamed fields (tuple structs)")"#.parse().unwrap();
+        }
+    };
+}
+
+/// # Parses derive macro input.
+///
+/// Please prefer the use of crate::parser::parse_input!
+/// when in a _proc_macro_derive_ function.
+///
+/// ## Success
+///
+/// In case of success, returns tuple with:
+/// Vector of field idents ( Vec<syn::Ident> );
+/// Vector of field types  ( Vec<syn::Type>  );
+/// Ident (name) of the parsed struct (syn::Ident);
+///
+/// ---
+///
+/// ## Error
+///
+/// In case of wrong input, it returns crate::errors::Error::InvalidStructErr.
+pub fn parse_derive_input(input: &DeriveInput) -> Result<(Vec<Ident>, Vec<Type>, Ident), Error> {
+    let fields = if let Data::Struct(DataStruct {
+        fields: ref named, ..
+    }) = input.data
+    {
+        named
+    } else {
+        return Err(Error::InvalidStructErr);
+    };
+
+    let mut names = Vec::with_capacity(fields.len());
+    let mut types = Vec::with_capacity(fields.len());
+
+    for x in fields {
+        names.push(x.ident.clone().unwrap());
+        types.push(x.ty.clone());
+    }
+
+    Ok((names, types, input.ident.clone()))
+}
+


### PR DESCRIPTION
Codebase refactor of the `hopper_macro` crate with a good amount of detailed docstrings introduced.
Added `Derive(Serialize)` procedural macro to public API.
Minor version bump from `0.1.0` to `0.2.0`.

Changes have **not** yet been **tested** nor have they been implemented to the `hopper` codebase.

**Testing is needed**.